### PR TITLE
Allow KeyboardInterrupt out of Flow.process_notifications()

### DIFF
--- a/src/flow.py
+++ b/src/flow.py
@@ -601,7 +601,7 @@ class Flow(object):
                 break
             try:
                 session.consume_notification(timeout_secs)
-            except:
+            except Exception:
                 # Log error and keep looping
                 LOG.exception("consume_notification failed")
         LOG.debug("process_notifications done")


### PR DESCRIPTION
@lucasmrod @alanfairless 

Noticed that our except was too broad in the process_notifications() loop.  Not sure the best way to fix, but figured that grabbing the KeyboardInterrupt and clearing the signal at least worked.

I am open to other suggestions.