### PR TITLE
include org as Parent for Event

### DIFF
--- a/src/flow.py
+++ b/src/flow.py
@@ -1850,12 +1850,13 @@ class Flow(object):
             timeout=timeout,
         )
 
-    def new_auto_add_to_channels_pref(self, channels, sid=0, timeout=None):
+    def new_auto_add_to_channels_pref(self, org, channels, sid=0, timeout=None):
         """Returns a dict for the preferences for the provided oid"""
         sid = self._get_session_id(sid)
         return self._run(
             method="NewAutoAddToChannelsPref",
             SessionID=sid,
+            OrgHashID=org,
             ChannelHashIDs=channels,
             timeout=timeout,
         )


### PR DESCRIPTION
Support AutoAddToChannels Event by adding org hash id as an additional argument to new_auto_add_to_channels_pref