### PR TITLE
Use install_requires, rather than parsing requirements.txt, in setup.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-requests>=2.2.1
-semantic-version==2.6.0

--- a/setup.py
+++ b/setup.py
@@ -1,20 +1,15 @@
 from setuptools import setup
 
-try:
-    from pip.req import parse_requirements
-except ImportError:
-    print("The 'pip' package is needed for the setup")
-    exit(1)
-
-reqs = parse_requirements("requirements.txt", session=False)
-install_requires = [str(ir.req) for ir in reqs]
 
 setup(
     name="flow-python",
     version="0.6",
     package_dir={"flow": "src"},
     packages=["flow"],
-    install_requires=install_requires,
+    install_requires=[
+        'requests>=2.2.1',
+        'semantic-version==2.6.0',
+    ],
     keywords=["spideroak", "flow", "semaphor"],
     author="Lucas Manuel Rodriguez",
     author_email="lucas@spideroak-inc.com",

--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,8 @@ setup(
     package_dir={"flow": "src"},
     packages=["flow"],
     install_requires=[
-        'requests>=2.2.1',
-        'semantic-version==2.6.0',
+        "requests>=2.2.1",
+        "semantic-version==2.6.0",
     ],
     keywords=["spideroak", "flow", "semaphor"],
     author="Lucas Manuel Rodriguez",


### PR DESCRIPTION
Hey there, thanks for your work!

The existing `setup.py` [breaks when using pip >= 10](https://stackoverflow.com/a/49867265). This PR moves the contents of `requirements.txt` to `install_requires` directly, per setuptools convention [for declaring dependencies](http://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-dependencies).